### PR TITLE
Don't add joined-field twice.

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -428,6 +428,7 @@ class SqlGenerator {
 			Join join = getJoin(extPath);
 			if (join != null) {
 				joinTables.add(join);
+				continue;
 			}
 
 			Column column = getColumn(extPath);


### PR DESCRIPTION
The join-relationship field should not be added to 'columnExpressions', It's conflicted with the joined table field.  Which caused 'ResultSet contains [join-field] multiple times';